### PR TITLE
[Fix] 스튜디오 필터 API - 경로 수정

### DIFF
--- a/app/src/main/java/com/example/toucheeseapp/data/network/ToucheeseServer.kt
+++ b/app/src/main/java/com/example/toucheeseapp/data/network/ToucheeseServer.kt
@@ -24,7 +24,7 @@ interface ToucheeseServer {
     ): StudioResponse
 
     // 필터 적용 후 스튜디오 목록 조회
-    @GET("v1/concepts/{conceptId}/filters")
+    @GET("v1/concepts/{conceptId}/studios/filters")
     suspend fun filterStudio(
         @Path("conceptId") conceptId: Int,
         @Query("page") page: Int,


### PR DESCRIPTION
- 스튜디오 필터 API 적용 안 되던 문제 해결
- 원인 : API 경로가 달라지면서 발생한 문제 
- 해결방법: API 경로 수정