### PR TITLE
[Fix] UI 수정

### DIFF
--- a/app/src/main/java/com/example/toucheeseapp/data/model/studio_detail/OperatingHour.kt
+++ b/app/src/main/java/com/example/toucheeseapp/data/model/studio_detail/OperatingHour.kt
@@ -1,6 +1,6 @@
 package com.example.toucheeseapp.data.model.studio_detail
 
-data class OperationiHours(
+data class OperatingHour(
     val dayOfWeek: String,
     val openTime: String,
     val closeTime: String,

--- a/app/src/main/java/com/example/toucheeseapp/data/model/studio_detail/StudioDetailResponse.kt
+++ b/app/src/main/java/com/example/toucheeseapp/data/model/studio_detail/StudioDetailResponse.kt
@@ -16,8 +16,8 @@ data class StudioDetailResponse(
     val name: String,
     @SerializedName("notice")
     val notice: String,
-    @SerializedName("operationHour")
-    val operationHour: String,
+    @SerializedName("operatingHours")
+    val operatingHours: List<OperatingHour>,
     @SerializedName("products")
     val products: List<Product>,
     @SerializedName("profileImage")

--- a/app/src/main/java/com/example/toucheeseapp/ui/components/StudioInfoComponent.kt
+++ b/app/src/main/java/com/example/toucheeseapp/ui/components/StudioInfoComponent.kt
@@ -2,13 +2,26 @@ package com.example.toucheeseapp.ui.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -23,10 +36,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.rememberAsyncImagePainter
 import com.example.toucheeseapp.data.model.studio_detail.StudioDetailResponse
+import io.github.boguszpawlowski.composecalendar.kotlinxDateTime.now
+import kotlinx.datetime.LocalDate
 
 @Composable
 fun StudioInfoComponent(
@@ -35,13 +51,10 @@ fun StudioInfoComponent(
 ) {
 
     var isExpanded by remember { mutableStateOf(false) } // 펼치기/접기
-
+    val (isOperationHoursExpanded, setOperationHoursExpanded) = remember { mutableStateOf(false) }
 
     Column(
-        modifier = Modifier
-            .fillMaxWidth() // 화면 너비를 채움
-            .background(Color(0xFFFFF2CC)) // 노란 배경
-            .clip(RoundedCornerShape(8.dp)) // 모서리 둥글게
+        modifier = modifier
     ) {
         // 노란 배경 안에 로고와 스튜디오 이름
         Column(
@@ -94,12 +107,11 @@ fun StudioInfoComponent(
             modifier = Modifier
                 .fillMaxWidth() // 화면 너비 꽉 채우기
                 .background(Color.White) // 하얀 배경
-                .padding(vertical = 16.dp) // 내부 여백 설정
+                .padding(16.dp) // 내부 여백 설정
         ) {
             // 평점과 하트 아이콘
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 16.dp) // 좌우 패딩
             ) {
                 Icon(
                     imageVector = Icons.Default.Favorite,
@@ -113,21 +125,93 @@ fun StudioInfoComponent(
                     style = MaterialTheme.typography.bodyMedium
                 )
             }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // 운영시간과 주소
-            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                Text(
-                    text = "운영시간: ${studio.operationHour}",
-                    style = MaterialTheme.typography.bodyMedium
+            // 주소
+            Row {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = "Location Icon",
+                    modifier = Modifier.size(16.dp)
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.width(4.dp))
                 Text(
                     text = "주소: ${studio.address}",
-                    style = MaterialTheme.typography.bodyMedium
+                    style = MaterialTheme.typography.bodyMedium,
                 )
+            }
+
+            // 운영시간
+            Column(
+                modifier = Modifier
+                    .wrapContentWidth(Alignment.End)
+                    .clickable {
+                        // 확장 클릭 반대로
+                        setOperationHoursExpanded(!isOperationHoursExpanded)
+                    }
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.DateRange,
+                        contentDescription = "Operation Hours",
+                        modifier = Modifier.size(16.dp)
+                    )
+
+                    Spacer(modifier = Modifier.width(4.dp))
+
+                    Text(
+                        text = "운영시간:",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Icon(
+                        imageVector = if (isOperationHoursExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (isOperationHoursExpanded) "운영시간 열림" else "운영시간 접힘",
+                    )
+                }
+                // 운영 시간
+                if (isOperationHoursExpanded) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    ) {
+                        // 오늘 날짜
+                        val today = getCurrentDayOfWeekInKorean()
+                        studio.operatingHours.forEach { operatingHour ->
+                            // 요일
+                            if (operatingHour.openTime == "휴무") { // 휴무일
+                                Text(
+                                    text = "${operatingHour.dayOfWeek} ---- 휴무일 ----",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.Red,
+                                    fontWeight = if (operatingHour.dayOfWeek == today) FontWeight.Bold else FontWeight.Medium
+                                )
+                            } else {
+
+                                Text(
+                                    text = "${operatingHour.dayOfWeek} ${operatingHour.openTime} ~ ${operatingHour.closeTime}",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = if (operatingHour.dayOfWeek == today) FontWeight.Bold else FontWeight.Medium
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }
+}
+
+// 오늘 요일 구하기
+fun getCurrentDayOfWeekInKorean(): String {
+    val today = LocalDate.now()
+    val koreanDays = mapOf(
+        "MONDAY" to "월",
+        "TUESDAY" to "화",
+        "WEDNESDAY" to "수",
+        "THURSDAY" to "목",
+        "FRIDAY" to "금",
+        "SATURDAY" to "토",
+        "SUNDAY" to "일"
+    )
+    return koreanDays[today.dayOfWeek.name] ?: "Unknown Day"
 }

--- a/app/src/main/java/com/example/toucheeseapp/ui/components/TabBarComponent.kt
+++ b/app/src/main/java/com/example/toucheeseapp/ui/components/TabBarComponent.kt
@@ -41,7 +41,12 @@ fun TabBarComponent(
                         if (selectedTabIndex == index) Color(0xFFFFC000) else Color(0xFFFFF2CC)
                     )
             ) {
-                Text(title, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(8.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(8.dp),
+                    color = Color.White
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/toucheeseapp/ui/screens/tab_Home/StudioDetailScreen.kt
+++ b/app/src/main/java/com/example/toucheeseapp/ui/screens/tab_Home/StudioDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.example.toucheeseapp.ui.screens.tab_Home
 
 import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,6 +26,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.toucheeseapp.ui.components.BottomActionButtons
@@ -101,7 +105,13 @@ fun StudioDetailScreen(
 
                 // 스튜디오 정보
                 item {
-                    StudioInfoComponent(studio = studio!!)
+                    StudioInfoComponent(
+                        studio = studio!!,
+                        modifier = Modifier
+                        .fillMaxWidth() // 화면 너비를 채움
+                        .background(Color(0xFFFFF2CC)) // 노란 배경
+                        .clip(RoundedCornerShape(8.dp)) // 모서리 둥글게
+                   )
                 }
 
                 // 탭 컴포넌트

--- a/app/src/main/java/com/example/toucheeseapp/ui/viewmodel/StudioViewModel.kt
+++ b/app/src/main/java/com/example/toucheeseapp/ui/viewmodel/StudioViewModel.kt
@@ -56,10 +56,6 @@ class StudioViewModel @Inject constructor(
             }
 
             _isSearching.value = true // 검색 시작
-            Log.d(
-                "SearchState",
-                "Searching for keyword: $keyword, isSearching: ${_isSearching.value}"
-            )
 
             try {
 


### PR DESCRIPTION
# 관련이슈
- #73 

# 관련 화면
- 스튜디오 상세 조회 페이지

# 수정 내용
- 운영시간 서버에서 받아오는 DTO 수정 
- 운영시간 클릭 시 리스트로 보여주도록 수정
- 오늘 날짜에 해당하는 요일은 굵은 글씨로 나오도록 수정
- 탭 글씨 색상 변경 -> 흰색
- 휴무일은 빨간 글씨로 나오도록 수정
# 관련 이미지
<img width="442" alt="스크린샷 2024-12-09 오전 1 27 22" src="https://github.com/user-attachments/assets/050607e3-40a2-4c2e-88e4-8bba4e2a1738">

<img width="434" alt="스크린샷 2024-12-09 오전 1 27 45" src="https://github.com/user-attachments/assets/58cd9a2c-f2dc-441f-8629-2c633e84da20">
